### PR TITLE
feat: add Dockerfile and docker-compose for Ghost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /app/requirements.txt
+
+# Normalize requirements encoding to UTF-8 in case the source file is UTF-16.
+RUN python -c "from pathlib import Path; p=Path('/app/requirements.txt'); raw=p.read_bytes(); text=raw.decode('utf-16') if raw.startswith((b'\\xff\\xfe', b'\\xfe\\xff')) else raw.decode('utf-8'); p.write_text(text, encoding='utf-8')"
+
+RUN pip install --upgrade pip \
+    && pip install -r /app/requirements.txt
+
+COPY . /app
+
+RUN mkdir -p /app/data
+
+CMD ["python", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  ghostcommander:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: ghostcommander
+    env_file:
+      - .env
+    restart: unless-stopped
+    init: true
+    volumes:
+      - ./data:/app/data


### PR DESCRIPTION
## Summary
This PR containerizes GhostCommander with a lightweight Python image and adds Docker Compose support with persistent bot memory storage.

Closes #2.

## What changed
- Added `Dockerfile` based on `python:3.11-slim`.
- Installed required system packages (`git`, `ca-certificates`) for runtime git operations used by the bot.
- Added dependency install flow with requirements normalization.
- Added `docker-compose.yml` with:
  - Build config
  - `.env` passthrough via `env_file`
  - `restart: unless-stopped`
  - Persistent volume mapping: `./data:/app/data`

## Why
GhostCommander previously required native venv setup.  
This enables easier deployment for new users and cloud environments while preserving SQLite-backed memory across restarts.

## Validation
- Checked compose config rendering.
- Confirmed volume mapping persists `data/dev_stats.db`.
- Verified container startup command points to `main.py`.
